### PR TITLE
QOL fix: index week on sunday

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,8 +19,8 @@ var dayProgress = setInterval(function() {
 var weekProgress = setInterval(function() {
 
   // Get todays date and time
-  var sow = moment().startOf('isoWeek');
-  var eow = moment().add(1, 'w').startOf('isoWeek');
+  var sow = moment().startOf('week');
+  var eow = moment().startOf('week').add(1, 'w');
   var total = eow.diff(sow)
   var now = moment();
   var distance = eow.diff(now);


### PR DESCRIPTION
Hey Paul,

Love the extension, been using it for like a month now. Thought it made sense to index weeks on Sunday (instead of Monday) as the first day of the week to keep it in line with most calendars. Let me know what you think!